### PR TITLE
Exits gracefully when semiphemeral stats is run without configuration

### DIFF
--- a/semiphemeral/twitter.py
+++ b/semiphemeral/twitter.py
@@ -35,6 +35,8 @@ class Twitter(object):
         self.last_fetch_format = '%Y-%m-%d %I:%M%p'
 
     def stats(self):
+        if not self.common.settings.is_configured():
+            return
         click.secho('Statistics', fg='cyan')
         stats = self.common.get_stats()
         click.echo(json.dumps(stats, indent=2))


### PR DESCRIPTION
If you didn't configure things and run `semiphemeral stats` you'd get the no configuration error message, but also the app would continue and ultimately crash like so:

```
semiphemeral 0.2
Twitter API is not configured yet, configure it with --configure
Statistics
Traceback (most recent call last):
  File "./app.py", line 3, in <module>
    semiphemeral.main()
  File "/home/bim/.local/share/virtualenvs/semiphemeral-HoVkjQIH/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/bim/.local/share/virtualenvs/semiphemeral-HoVkjQIH/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/bim/.local/share/virtualenvs/semiphemeral-HoVkjQIH/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/bim/.local/share/virtualenvs/semiphemeral-HoVkjQIH/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/bim/.local/share/virtualenvs/semiphemeral-HoVkjQIH/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/bim/semiphemeral/semiphemeral/__init__.py", line 44, in stats
    t.stats()
  File "/home/bim/semiphemeral/semiphemeral/twitter.py", line 39, in stats
    stats = self.common.get_stats()
  File "/home/bim/semiphemeral/semiphemeral/common.py", line 22, in get_stats
    my_tweets = self.session.execute('SELECT COUNT(*) FROM tweets WHERE user_id={} AND is_deleted=0 AND is_retweet=0'.format(int(self.settings.get('user_id')))).first()[0]
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
```

This just adds a `return` statement making the app exit cleanly like when you run `fetch` or `delete` without configuration.