### PR TITLE
fix documentation copy to more closely match what users see

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Semiphemeral is a command line tool that you run locally on your computer, or on
 
 ```
 $ semiphemeral
-Usage: app.py [OPTIONS] COMMAND [ARGS]...
+Usage: semiphemeral [OPTIONS] COMMAND [ARGS]...
 
   Automatically delete your old tweets, except for the ones you want to keep
 


### PR DESCRIPTION
Very small documentation update. I'm not familiar enough with `click` to know how to change what I think they call the `prog_name` in the usage notes (which defaults to `sys.argv[0]`), but that's probably not important as likely only developers will see it as `app.py`. In practice, most end users will see `semiphemeral` so I think that's what the README should say!