### PR TITLE
Fetch 280-character tweets

### DIFF
--- a/semiphemeral/db.py
+++ b/semiphemeral/db.py
@@ -56,7 +56,7 @@ class Tweet(Base):
         self.lang = status.lang
         self.source = status.source
         self.source_url = status.source_url
-        self.text = status.text
+        self.text = status.full_text
         self.in_reply_to_screen_name = status.in_reply_to_screen_name
         self.in_reply_to_status_id = status.in_reply_to_status_id
         self.in_reply_to_user_id = status.in_reply_to_user_id

--- a/semiphemeral/twitter.py
+++ b/semiphemeral/twitter.py
@@ -55,7 +55,8 @@ class Twitter(object):
             for page in tweepy.Cursor(
                 self.api.user_timeline,
                 id=self.common.settings.get('username'),
-                since_id=since_id
+                since_id=since_id,
+                tweet_mode='extended'
             ).pages():
                 fetched_count = 0
 
@@ -125,7 +126,8 @@ class Twitter(object):
             for page in tweepy.Cursor(
                 self.api.favorites,
                 id=self.common.settings.get('username'),
-                since_id=like_since_id
+                since_id=like_since_id,
+                tweet_mode='extended'
             ).pages():
                 # Import these tweets
                 for status in page:
@@ -180,7 +182,7 @@ class Twitter(object):
             if not parent_tweet:
                 # If not, import it
                 try:
-                    status = self.api.get_status(tweet.in_reply_to_status_id)
+                    status = self.api.get_status(tweet.in_reply_to_status_id, tweet_mode='extended')
                     fetched_count += self.import_tweet(Tweet(status))
                 except tweepy.error.TweepError:
                     # If it's been deleted, ignore


### PR DESCRIPTION
Tweepy by default only fetches 140 character tweets. This changes it to
fetch the full 280 characters so the sqlite database is more useful.