### PR TITLE
Archive import

### DIFF
--- a/semiphemeral/__init__.py
+++ b/semiphemeral/__init__.py
@@ -70,6 +70,13 @@ def delete():
     if common.settings.is_configured():
         t.delete()
 
+@main.command('import', short_help='Import tweets from a Twitter data export')
+@click.argument('path', type=click.Path(exists=True))
+def archive_import(path):
+    common = init()
+    t = Twitter(common)
+    t.import_dump(path)
+
 
 @main.command(
     "unlike",

--- a/semiphemeral/db.py
+++ b/semiphemeral/db.py
@@ -57,9 +57,11 @@ class Tweet(Base):
         self.source = status.source
         self.source_url = status.source_url
         self.text = status.full_text
-        self.in_reply_to_screen_name = status.in_reply_to_screen_name
-        self.in_reply_to_status_id = status.in_reply_to_status_id
-        self.in_reply_to_user_id = status.in_reply_to_user_id
+
+        # These fields don't exist in imported non-reply tweets
+        for field in ('in_reply_to_screen_name', 'in_reply_to_status_id', 'in_reply_to_user_id'):
+            setattr(self, field, getattr(status, field, None))
+
         self.retweet_count = status.retweet_count
         self.favorite_count = status.favorite_count
         self.retweeted = status.retweeted


### PR DESCRIPTION
This PR is a bit messy for reasons mentioned below. It's working fine for me so I'm going to raise this PR mostly so I don't forget about it.

This PR adds a feature to use a Twitter archive export to initially populate the semiphemeral DB. This has the following advantages:

* It's a lot faster as it hits fewer rate limits
* It allows you to delete tweets which don't appear in the API due to...[timeline anomalies](https://help.twitter.com/en/using-twitter/missing-tweets). Such as if you accidentally run semiphemeral with an incomplete dataset, which is what I did.

You run it by requesting your archive, unzipping it, and then running `semiphemeral import path/to/archive_dir`.

# Issues
* The archive I just downloaded from Twitter does not appear to flag retweets as such - they just appear (and get inserted into the DB) as normal tweets. I can't work out if this is a Twitter bug or not. I'm not too concerned about this as I want to delete retweets as well.
* The Twitter archive has likes, but with extremely little metadata so they'd require a metadata fetch for each like. I don't have the patience for that so I didn't implement importing of likes.
* There's probably a bit of scope for more refactoring.

This depends on #22.