### PR TITLE
Filter out keybase proofs

### DIFF
--- a/semiphemeral/common.py
+++ b/semiphemeral/common.py
@@ -14,24 +14,15 @@ class Common:
 
         is_configured = self.settings.is_configured()
         last_fetch = self.settings.get('last_fetch')
-        my_tweets = self.session.execute(
-            'SELECT COUNT(*) FROM tweets WHERE user_id={} AND is_deleted=0 AND is_retweet=0'.format(int(self.settings.get('user_id')))).first()[0]
-        my_retweets = self.session.execute(
-            'SELECT COUNT(*) FROM tweets WHERE user_id={} AND is_deleted=0 AND is_retweet=1'.format(int(self.settings.get('user_id')))).first()[0]
-        my_likes = self.session.execute(
-            'SELECT COUNT(*) FROM tweets WHERE favorited=1').first()[0]
-        deleted_tweets = self.session.execute(
-            'SELECT COUNT(*) FROM tweets WHERE user_id={} AND is_deleted=1 AND is_retweet=0'.format(int(self.settings.get('user_id')))).first()[0]
-        deleted_retweets = self.session.execute(
-            'SELECT COUNT(*) FROM tweets WHERE user_id={} AND is_deleted=1 AND is_retweet=1'.format(int(self.settings.get('user_id')))).first()[0]
-        unliked_tweets = self.session.execute(
-            'SELECT COUNT(*) FROM tweets WHERE favorited=1 AND is_unliked=1').first()[0]
-        excluded_tweets = self.session.execute(
-            'SELECT COUNT(*) FROM tweets WHERE user_id={} AND exclude_from_delete=1'.format(int(self.settings.get('user_id')))).first()[0]
-        other_tweets = self.session.execute(
-            'SELECT COUNT(*) FROM tweets WHERE user_id!={}'.format(int(self.settings.get('user_id')))).first()[0]
-        threads = self.session.execute(
-            'SELECT COUNT(*) FROM threads').first()[0]
+        my_tweets = self.session.execute('SELECT COUNT(*) FROM tweets WHERE user_id={} AND is_deleted=0 AND is_retweet=0'.format(int(self.settings.get('user_id')))).first()[0]
+        my_retweets = self.session.execute('SELECT COUNT(*) FROM tweets WHERE user_id={} AND is_deleted=0 AND is_retweet=1'.format(int(self.settings.get('user_id')))).first()[0]
+        my_likes = self.session.execute('SELECT COUNT(*) FROM tweets WHERE favorited=1').first()[0]
+        deleted_tweets = self.session.execute('SELECT COUNT(*) FROM tweets WHERE user_id={} AND is_deleted=1 AND is_retweet=0'.format(int(self.settings.get('user_id')))).first()[0]
+        deleted_retweets = self.session.execute('SELECT COUNT(*) FROM tweets WHERE user_id={} AND is_deleted=1 AND is_retweet=1'.format(int(self.settings.get('user_id')))).first()[0]
+        unliked_tweets = self.session.execute('SELECT COUNT(*) FROM tweets WHERE favorited=1 AND is_unliked=1').first()[0]
+        excluded_tweets = self.session.execute('SELECT COUNT(*) FROM tweets WHERE user_id={} AND exclude_from_delete=1'.format(int(self.settings.get('user_id')))).first()[0]
+        other_tweets = self.session.execute('SELECT COUNT(*) FROM tweets WHERE user_id!={}'.format(int(self.settings.get('user_id')))).first()[0]
+        threads = self.session.execute('SELECT COUNT(*) FROM threads').first()[0]
 
         return {
             'is_configured': is_configured,


### PR DESCRIPTION
This PR adds a filter so that keybase proofs are not included in the tweets to delete. It does this by detecting a substring.