### PR TITLE
Configurable web server bind address

### DIFF
--- a/semiphemeral/__init__.py
+++ b/semiphemeral/__init__.py
@@ -31,16 +31,17 @@ def main():
 
 @main.command("configure", short_help="Start the web server to configure semiphemeral")
 @click.option("--debug", is_flag=True, help="Start web server in debug mode")
+@click.option("--host", default="127.0.0.1", help="Host to expose the web server on")
 @click.option("--port", default=8080, help="Port to expose the web server on")
-def configure(debug, port):
+def configure(debug, host, port):
     common = init()
     click.echo(
         "Load this website in a browser to configure semiphemeral, and press Ctrl-C when done"
     )
-    click.echo("http://127.0.0.1:{port}".format(port=port))
+    click.echo("http://{host}:{port}".format(host=host, port=port))
     click.echo("")
     app = create_app(common)
-    app.run(host="127.0.0.1", port=port, threaded=False, debug=debug)
+    app.run(host=host, port=port, threaded=False, debug=debug)
 
 
 @main.command("stats", short_help="Show stats about tweets in the database")


### PR DESCRIPTION
I'm running Semiphemeral in Docker, and the hard-coded `127.0.0.1` web server bind address means I'm forced to use Docker's 'host' networking (as far as I can tell). For flexibility, I'd like some way to set a different IP.

This PR adds a `semiphemeral configure --host` option, to complement the existing `--port` option.