### PR TITLE
Update DM file expected attributes.

### DIFF
--- a/semiphemeral/twitter.py
+++ b/semiphemeral/twitter.py
@@ -678,17 +678,17 @@ class Twitter(object):
         if not os.path.isfile(filename):
             click.echo("Invalid file")
             return
-        if os.path.basename(filename) != "direct-message.js":
-            click.echo("File should be called direct-message.js")
+        if os.path.basename(filename) not in ("direct-messages.js", "direct-messages.js"):
+            click.echo("File should be called direct-message.js or direct-messages.js")
             return
 
         # Validate file format
         with open(filename) as f:
-            expected_start = "window.YTD.direct_message.part0 = "
+            expected_start = "window.YTD.direct_message"
             js_string = f.read()
             if not js_string.startswith(expected_start):
                 click.echo(
-                    "File expected to start with: `window.YTD.direct_message.part0 = `"
+                    "File expected to start with: `window.YTD.direct_message`"
                 )
                 return
             json_string = js_string[len(expected_start) :]


### PR DESCRIPTION
Twitter now stores DMs in "direct-messages.js" and the first line
of the file now reflects the plural use of "messages" over "message".

This change aims to be backward compatible, simply searching for the
string "window.YTD.direct_message" at the beginning of the file, and
accepting filenames that are either plural or singular.