### PR TITLE
Fix bugs/typos in delete_dms command

### DIFF
--- a/semiphemeral/settings.py
+++ b/semiphemeral/settings.py
@@ -54,6 +54,7 @@ class Settings(object):
 
     def save(self):
         with open(self.filename, "w") as f:
+            os.chmod(self.filename, 0o0600)
             json.dump(self.settings, f)
 
     def is_configured(self):

--- a/semiphemeral/settings.py
+++ b/semiphemeral/settings.py
@@ -30,7 +30,7 @@ class Settings(object):
             "logging": False,
             "log_filename": os.path.expanduser("~/.semiphemeral/log"),
             "log_format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-            'proxy': None,
+            'proxy': "",
             'use_tor': False,
         }
         self.load()

--- a/semiphemeral/twitter.py
+++ b/semiphemeral/twitter.py
@@ -690,7 +690,7 @@ class Twitter(object):
                     "File expected to start with: `window.YTD.direct_message`"
                 )
                 return
-            json_string = js_string[len(expected_start) :]
+            json_string = js_string[js_string.find("[") :]
             try:
                 conversations = json.loads(json_string)
             except:

--- a/semiphemeral/twitter.py
+++ b/semiphemeral/twitter.py
@@ -678,7 +678,7 @@ class Twitter(object):
         if not os.path.isfile(filename):
             click.echo("Invalid file")
             return
-        if os.path.basename(filename) not in ("direct-messages.js", "direct-messages.js"):
+        if os.path.basename(filename) not in ("direct-message.js", "direct-messages.js"):
             click.echo("File should be called direct-message.js or direct-messages.js")
             return
 

--- a/semiphemeral/twitter.py
+++ b/semiphemeral/twitter.py
@@ -27,8 +27,11 @@ class Twitter(object):
             self.common.settings.get("access_token_key"),
             self.common.settings.get("access_token_secret"),
         )
+        proxy=self.common.settings.get('proxy')
+        if proxy == "":
+            proxy = None
         self.api = tweepy.API(
-            auth, wait_on_rate_limit=True, wait_on_rate_limit_notify=True, proxy=self.common.settings.get('proxy')
+            auth, wait_on_rate_limit=True, wait_on_rate_limit_notify=True, proxy=proxy
         )
 
         self.authenticated = True

--- a/semiphemeral/twitter.py
+++ b/semiphemeral/twitter.py
@@ -431,6 +431,15 @@ class Twitter(object):
             # Fetch direct messages
             count = 0
             for page in tweepy.Cursor(self.api.list_direct_messages).pages():
+                # Twitter will return an apparently unlimited number of empty DM responses
+                # in certain cases, which will hit the rate limit very quickly (15 per 15
+                # minutes, currently). Exit if we get an empty response.
+                if not page:
+                    click.secho(
+                        "No more accessible DMs", fg="cyan"
+                    )
+                    break
+
                 for dm in page:
                     created_timestamp = datetime.datetime.fromtimestamp(
                         int(dm.created_timestamp) / 1000

--- a/semiphemeral/twitter.py
+++ b/semiphemeral/twitter.py
@@ -3,7 +3,6 @@ import click
 import json
 import datetime
 import os
-import json
 import time
 
 from .db import Tweet, Thread

--- a/semiphemeral/web.py
+++ b/semiphemeral/web.py
@@ -96,7 +96,7 @@ def create_app(common):
                 "dms_days_threshold", int(request.form["dms_days_threshold"])
             )
 
-            common.settings.set('proxy', request.form['proxy'])
+            common.settings.set('proxy', request.form['proxy'].strip())
             common.settings.set('use_tor', 'use_tor' in request.form)
 
             common.settings.save()


### PR DESCRIPTION
- Fix two bugs preventing delete_dms from running.
- Fix bug in proxy setting code preventing settings from being saved if proxy was not set.
- Make sure settings file is not world-readable even if umask is standard 0022.
- Bail out of possibly endless loop returning empty DMs.