### PR TITLE
Fix crash when loading like.js

### DIFF
--- a/semiphemeral/twitter.py
+++ b/semiphemeral/twitter.py
@@ -462,7 +462,7 @@ class Twitter(object):
             return
 
         # Validate file format
-        with open(filename) as f:
+        with open(filename, encoding="utf8") as f:
             expected_start = "window.YTD.like.part0 = "
             js_string = f.read()
             if not js_string.startswith(expected_start):


### PR DESCRIPTION
when loading like.js it will fail to parse. ( on my windows machine at least ) :

```
return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 37121: character maps to <undefined>
```

This can be fix by opening the file as utf-8