### PR TITLE
Stay with Tweepy <4.0 due to API changes

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,7 +12,7 @@ click = "*"
 colorama = "*"
 flask = "*"
 sqlalchemy = "*"
-tweepy = ">=3.9.0"
+tweepy = "~=3.10"
 
 [requires]
 python_version = "3"


### PR DESCRIPTION
Tweepy has significantly changed its API in 4.0, so for now stay on the
3.10 series.