### PR TITLE
Show tweets ready to be deleted in stats

### DIFF
--- a/semiphemeral/common.py
+++ b/semiphemeral/common.py
@@ -65,6 +65,7 @@ class Common:
             )
         ).first()[0]
         threads = self.session.execute("SELECT COUNT(*) FROM threads").first()[0]
+        tweets_to_delete = self.get_tweets_to_delete()
 
         return {
             "is_configured": is_configured,
@@ -78,6 +79,7 @@ class Common:
             "excluded_tweets": excluded_tweets,
             "other_tweets": other_tweets,
             "threads": threads,
+            "tweets_to_delete": len(tweets_to_delete),
         }
 
     def get_tweets_to_delete(self, include_excluded=False):

--- a/semiphemeral/static/js/base.js
+++ b/semiphemeral/static/js/base.js
@@ -8,6 +8,7 @@ $(function () {
     $('.statistics .is_configured').text(is_configured);
     $('.statistics .last_fetch').text(data.last_fetch);
     $('.statistics .my_tweets').text(comma_formatted(data.my_tweets));
+    $('.statistics .tweets_to_delete').text(comma_formatted(data.tweets_to_delete));
     $('.statistics .my_retweets').text(comma_formatted(data.my_retweets));
     $('.statistics .my_likes').text(comma_formatted(data.my_likes));
     $('.statistics .deleted_tweets').text(comma_formatted(data.deleted_tweets));

--- a/semiphemeral/templates/base.html
+++ b/semiphemeral/templates/base.html
@@ -27,6 +27,7 @@
         <li><span class="value excluded_tweets"></span> excluded tweets</li>
         <li><span class="value other_tweets"></span> tweets from other users</li>
         <li><span class="value threads"></span> threads</li>
+        <li><span class="value tweets_to_delete"></span> tweets to delete</li>
       </ul>
     </div>
 

--- a/semiphemeral/twitter.py
+++ b/semiphemeral/twitter.py
@@ -50,6 +50,14 @@ class Twitter(object):
         stats = self.common.get_stats()
         click.echo(json.dumps(stats, indent=2))
 
+        if self.common.settings.get("delete_tweets"):
+            tweets_to_delete = self.common.get_tweets_to_delete()
+            click.secho(
+                "Want to delete {} tweets".format(len(tweets_to_delete)),
+                fg="cyan",
+            )
+
+
     def fetch(self):
         if not self.authenticated:
             return


### PR DESCRIPTION
Get a sense of tweets yet to be deleted, usually only visible when the
throttle has been hit.