### PR TITLE
twitter.py: Check tweepy version at run-time

### DIFF
--- a/semiphemeral/twitter.py
+++ b/semiphemeral/twitter.py
@@ -23,6 +23,13 @@ class Twitter(object):
             )
             return
 
+        # Check for tweepy version at run-time to avoid later crashes.
+        if not tweepy.__version__.startswith('3.10.'):
+            click.echo(
+                "Python package 'tweepy' must be version 3.10.x"
+            )
+            return
+
         auth = tweepy.OAuthHandler(
             self.common.settings.get("api_key"), self.common.settings.get("api_secret")
         )


### PR DESCRIPTION
For some reason people still end up with misconfigured installations
with bad Tweepy versions. Instead of crashing later with weird errors,
do a version check up front and refuse to do anything with a bad Tweepy
version.

Signed-off-by: Kees Cook <kees@outflux.net>