### PR TITLE
Js semiphemeral tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Semiphemeral is a command line tool that you run locally on your computer, or on
 
 ```
 $ semiphemeral
-Usage: -c [OPTIONS] COMMAND [ARGS]...
+Usage: semiphemeral [OPTIONS] COMMAND [ARGS]...
 
   Automatically delete your old tweets, except for the ones you want to keep
 
@@ -43,11 +43,11 @@ Commands:
   configure        Start the web server to configure semiphemeral
   delete           Delete tweets that aren't automatically or manually
                    excluded, likes, and DMs
-
   delete_dms       Delete DMs that aren't available through the Twitter API
   excluded_export  Export tweets excluded that are excluded from deletion
   excluded_import  Import tweets excluded that are excluded from deletion
   fetch            Download all tweets/DMs
+  import           Import tweets from a Twitter data export
   stats            Show stats about tweets in the database
   unlike           Delete old likes that aren't available through the Twitter
                    API

--- a/semiphemeral/twitter.py
+++ b/semiphemeral/twitter.py
@@ -794,14 +794,14 @@ class Twitter(object):
 
             if os.path.isdir(filepath):
                 # Unzipped tweet archive
-                with open(os.path.join(filepath, "data", "tweet.js"), "r", encoding="UTF-8") as f:
+                with open(os.path.join(filepath, "data", "tweets.js"), "r", encoding="UTF-8") as f:
                     # Skip the JS variable assignment at the start of this file
                     f.read(25)
                     tweets = json.load(f)
             elif os.path.splitext(filepath)[1] == ".zip":
                 # Zipped tweet archive
                 with ZipFile(filepath) as zipfile:
-                    with zipfile.open("data/tweet.js") as f:
+                    with zipfile.open("data/tweets.js") as f:
                         f = io.TextIOWrapper(f, "UTF-8")
                         # Skip the JS variable assignment at the start of this file
                         f.read(25)


### PR DESCRIPTION
Adjusting the name of the Tweet file to `data/tweets.js`; where it lives nowadays. And a change to the bare `semiphemeral` command to match what it currently looks like; was missing the `import` command previously.